### PR TITLE
fix: extract non-readable tags on http get tool

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2582,4 +2582,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "2cebdbe83e06dd233e889407b8bfba2e2a58eefc04323ad1adbb4cb8a31f8427"
+content-hash = "03cf9716adb9c6d543cd5a33094940f4ad394f0080ce5b22362906e1c3f72e97"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ optional = true
 psycopg2-binary = "^2.9.5"
 wikipedia = "^1.4.0"
 google-search-results = "^2.4.2"
+beautifulsoup4 = "^4.11.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tools/cpu.py
+++ b/tools/cpu.py
@@ -5,6 +5,7 @@ import requests
 from llama_index.readers.database import DatabaseReader
 from llama_index import GPTSimpleVectorIndex
 
+from bs4 import BeautifulSoup
 from langchain.memory.chat_memory import BaseChatMemory
 
 """Wrapper around subprocess to run commands."""
@@ -60,11 +61,20 @@ class RequestsGet(BaseToolSet):
     )
     def inference(self, url: str) -> str:
         """Run the tool."""
-        text = requests.get(url).text
+        html = requests.get(url).text
+        soup = BeautifulSoup(html)
+        non_readable_tags = soup.find_all(
+            ["script", "style", "header", "footer", "form"]
+        )
 
-        if len(text) > 100:
-            text = text[:100] + "..."
-        return text
+        for non_readable_tag in non_readable_tags:
+            non_readable_tag.extract()
+
+        content = soup.get_text("\n", strip=True)
+
+        if len(content) > 100:
+            content = content[:100] + "..."
+        return content
 
 
 class WineDB(BaseToolSet):

--- a/tools/cpu.py
+++ b/tools/cpu.py
@@ -72,8 +72,8 @@ class RequestsGet(BaseToolSet):
 
         content = soup.get_text("\n", strip=True)
 
-        if len(content) > 100:
-            content = content[:100] + "..."
+        if len(content) > 300:
+            content = content[:300] + "..."
         return content
 
 


### PR DESCRIPTION
- extract non-readable tags such as `script` or `style` on tool `RequestsGet` to save prompt tokens.